### PR TITLE
refactor: githubOverlay 의존 코드 제거 & popover 기반으로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ GitHub's native @mention autocomplete only suggests users that the current user 
 
 ## Solution
 
-GitHub Mentions+ augments GitHub's native @mention autocomplete by:
+GitHub Mentions+ augments GitHub's native @@mention autocomplete by:
 
-1. **Listening** for @ mentions in GitHub textareas and contenteditable elements
+1. **Listening** for @@ mentions in GitHub textareas and contenteditable elements
 2. **Fetching** custom user suggestions from a user-configurable endpoint OR direct JSON input
 3. **Displaying** suggestions in a native-looking overlay that complements GitHub's existing UI
 4. **Caching** results to minimize API calls and improve performance
@@ -31,7 +31,7 @@ GitHub Mentions+ augments GitHub's native @mention autocomplete by:
 3. Enable "Developer mode"
 4. Click "Load unpacked" and select the extension directory
 5. Click the extension icon to configure your data source
-6. Start using @mentions on GitHub!
+6. Start using @@mentions on GitHub!
 7. The extension will be installed and active on GitHub pages
 
 ### For Users
@@ -39,7 +39,7 @@ GitHub Mentions+ augments GitHub's native @mention autocomplete by:
 1. Download the extension from the browser store (coming soon)
 2. Install the extension
 3. Click the extension icon to configure your data source
-4. Start using @mentions on GitHub!
+4. Start using @@mentions on GitHub!
 
 ## Configuration
 

--- a/content_script.js
+++ b/content_script.js
@@ -353,9 +353,6 @@ function filterUsers(users, query) {
 
   // Get GitHub's current suggestions to avoid duplicates
   let githubUsernames = [];
-  if (window.GitHubMentionsDOM && typeof window.GitHubMentionsDOM.getGitHubSuggestions === 'function') {
-    githubUsernames = window.GitHubMentionsDOM.getGitHubSuggestions();
-  }
 
   // Filter out users that GitHub is already suggesting
   const filteredUsers = users.filter(user => 

--- a/content_script.js
+++ b/content_script.js
@@ -164,7 +164,7 @@ function insertMention(username) {
 }
 
 /**
- * Scan text for @ mention trigger
+ * Scan text for @@ mention trigger
  * @param {string} text - Text to scan
  * @param {number} pos - Cursor position
  * @returns {string|null} Username query or null
@@ -172,7 +172,7 @@ function insertMention(username) {
 function scanForTrigger(text, pos) {
   try {
     const slice = text.substring(0, pos);
-    const match = slice.match(/@([a-zA-Z0-9-_]*)$/);
+    const match = slice.match(/@@([a-zA-Z0-9-_]*)$/);
     return match ? match[1] : null;
   } catch (error) {
     return null;

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -6,16 +6,6 @@
 // Make utilities available globally
 window.GitHubMentionsDOM = {};
 
-/** <ul role="listbox" class="suggester-container suggester suggestions list-style-none position-absolute" id="text-expander-81574" style="left: calc(29.6953px); top: calc(3.5px);">      
-<li role="option" id="suggester-16604401-user-narashin" data-value="narashin" aria-selected="true">
-  <span>narashin</span>
-      <small>nara</small>
-  </li>    
-</ul> */
-const getGithubOverlay = () => {
-  return document.querySelector('.suggester-container');
-}
-
 /**
  * @typedef {Object} UserData
  * @property {string} username - GitHub username
@@ -94,9 +84,9 @@ window.GitHubMentionsDOM.updateOverlayPosition = function(activeInput) {
 
   const rect = activeInput.getBoundingClientRect();
   overlay.style.left = `${rect.left}px`;
-  overlay.style.top = `${rect.bottom + 6 + activeInput.scrollTop}px`; // account for scroll
-  overlay.style.width = `${rect.width}px`; // auto width for fallback
-  overlay.style.borderRadius = '0.75rem'; // full rounded corners for fallback
+  overlay.style.top = `${rect.bottom + 6 + activeInput.scrollTop}px`;
+  overlay.style.width = `${rect.width}px`;
+  overlay.style.borderRadius = '0.75rem';
   overlay.style.position = 'fixed';
   overlay.style.margin = "0";
   overlay.setAttribute("popover", "manual");
@@ -317,12 +307,6 @@ window.GitHubMentionsDOM.hideOverlay = function() {
     overlay.style.display = 'none';
     selectedIndex = 0;
     overlayItems = [];
-    
-    // Restore GitHub's overlay border radius to fully rounded when our overlay is hidden
-    const githubOverlay = document.querySelector('[class*="AutocompleteSuggestions-module__Overlay"]');
-    if (githubOverlay) {
-      githubOverlay.style.borderRadius = '0.75rem';
-    }
   }
 };
 
@@ -402,53 +386,3 @@ window.GitHubMentionsDOM.getSelectedItem = function() {
   }
   return null;
 };
-
-/**
- * Get usernames from GitHub's current suggestions to avoid duplicates
- * @returns {Array<string>} Array of usernames currently shown by GitHub
- */
-window.GitHubMentionsDOM.getGitHubSuggestions = function() {
-  try {
-    const githubOverlay = getGithubOverlay();
-    if (!githubOverlay || githubOverlay.style.display === 'none') {
-      return [];
-    }
-
-    // Look for suggestion items in GitHub's overlay
-    const suggestionItems = githubOverlay.querySelectorAll('[role="option"]');
-    
-    const usernames = [];
-    suggestionItems.forEach(item => {
-      // Try to extract username from various possible text patterns
-      const text = item.textContent || '';
-      
-      // Look for @username pattern
-      const atMatch = text.match(/@([a-zA-Z0-9-_]+)/);
-      if (atMatch) {
-        usernames.push(atMatch[1]);
-        return;
-      }
-      
-      // Look for username without @ (might be in a different element)
-      const usernameMatch = text.match(/([a-zA-Z0-9-_]+)/);
-      if (usernameMatch) {
-        usernames.push(usernameMatch[1]);
-        return;
-      }
-      
-      // Try to find username in child elements
-      const usernameElement = item.querySelector('[class*="username"], [class*="login"], strong, b');
-      if (usernameElement) {
-        const usernameText = usernameElement.textContent || '';
-        const cleanUsername = usernameText.replace(/@/, '').trim();
-        if (cleanUsername) {
-          usernames.push(cleanUsername);
-        }
-      }
-    });
-    
-    return usernames;
-  } catch (error) {
-    return [];
-  }
-}; 


### PR DESCRIPTION
### 배경

아래 현상을 해결합니다.
- @로 멘션 시, github의 것과 겹쳐 보이므로 불편
- 리뷰 팝업에서는 우리 팝업이 노출되지 않음

리뷰 팝업은 popover라는 속성을 쓰는데, 이건 body에서 z-index를 올려서는 대처가 안되고,
popover 기반으로 구성하고 show를 더 늦게해줘야 리뷰 팝업보다 위에 나오도록 할 수 있습니다. (기존엔 나왔는데 뒤에 가려서 안보인 것)


### 작업
- 이참에 GithubOverlay 기반 코드 싹 걷어냈습니다.
- 이제 @@로 멘션합니다.

<img width="818" height="452" alt="스크린샷 2025-09-16 오후 11 47 46" src="https://github.com/user-attachments/assets/a8116130-fff4-47b4-996a-693c5041e302" />

