### PR TITLE
fix: 오버레이 표시 및 Key Navigation을 통한 선택 인덱스 관리 개선

### DIFF
--- a/utils/dom.js
+++ b/utils/dom.js
@@ -336,9 +336,7 @@ function updateSelection() {
  */
 window.GitHubMentionsDOM.hideOverlay = function() {
   if (overlay) {
-    // 팝오버 사용하지 않고 디스플레이 속성만으로 숨김
     overlay.style.display = 'none';
-    // 선택 인덱스와 항목 리스트 초기화
     selectedIndex = 0;
     overlayItems = [];
   }
@@ -349,7 +347,6 @@ window.GitHubMentionsDOM.hideOverlay = function() {
  * @returns {boolean} True if overlay is visible
  */
 window.GitHubMentionsDOM.isOverlayVisible = function() {
-  // 단순히 display 속성만 확인
   return overlay && overlay.style.display !== 'none';
 };
 


### PR DESCRIPTION
  ### 개요
  - 화살표 키 사용 시 드롭다운 메뉴의 키보드 네비게이션 문제 수정
  - 선택 처리의 안정성을 향상시켜 포커스가 예기치 않게 첫 번째 항목으로 초기화되는 현상 방지

  ### 변경 사항
  - **fix**
    - popover API 사용을 제거하고 CSS 표시 방식으로 대체 (팝오버가 표시되고 숨겨질 때 내부 상태가 초기화 됨)
    - 현재 선택 상태 추적을 추가
    - 키보드 네비게이션 이벤트 간 지연 시간 추가

  ### 영향 영역 / 위험
  - 드롭다운 메뉴의 키보드 네비게이션
  - 자동완성 UI의 선택 처리
  - 오버레이 위치 지정을 위한 DOM 조작

  ### 검증
  - 다음 키보드 네비게이션 동작을 확인:
    1. 아래 화살표 키를 한 번 누르면 두 번째 항목으로 이동
    2. 첫 번째 항목에서 위 화살표 키를 한 번 누르면 마지막 항목으로 이동
    3. 여러 번 빠르게 화살표 키를 눌러도 예상 위치에 선택 상태 유지
    4. 드롭다운이 활성화된 상태에서 선택 항목 유지

  ### 연결된 이슈
  - Closes #11 