### PR TITLE
fix: 🐛 멘션 삽입 시 @가 2번 들어가지 않도록 수정, @연속 입력시 추가키워드 없이 최대 10명 바로 제안

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -442,7 +442,7 @@ async function onKeyUp(e) {
   
     // Handle @ mentions
     if (mentionQuery !== null) {
-      mentionStartPos = cursor - mentionQuery.length - 1; // position of the @
+      mentionStartPos = cursor - mentionQuery.length - 2; // position of the @@
     
       const users = await getUsersForSuggestions();
       const matches = filterUsers(users, mentionQuery);

--- a/content_script.js
+++ b/content_script.js
@@ -351,27 +351,12 @@ function filterUsers(users, query) {
     return [];
   }
 
-  // Get GitHub's current suggestions to avoid duplicates
-  let githubUsernames = [];
-
-  // Filter out users that GitHub is already suggesting
-  const filteredUsers = users.filter(user => 
-    !githubUsernames.some(githubUser => 
-      githubUser.toLowerCase() === user.username.toLowerCase()
-    )
-  );
-
-  if (filteredUsers.length === 0) {
-    return [];
-  }
-
-  // Only show suggestions when user has typed something after @
   if (!query) {
-    return [];
+    return users.slice(0, 10); // Show all users when no query (max 10)
   }
 
   const lowerQuery = query.toLowerCase();
-  const matchingUsers = filteredUsers.filter(user => 
+  const matchingUsers = users.filter(user => 
     user.username.toLowerCase().includes(lowerQuery) ||
     user.name.toLowerCase().includes(lowerQuery)
   );

--- a/content_script.js
+++ b/content_script.js
@@ -352,7 +352,7 @@ function filterUsers(users, query) {
   }
 
   if (!query) {
-    return users.slice(0, 10); // Show all users when no query (max 10)
+    return users;
   }
 
   const lowerQuery = query.toLowerCase();


### PR DESCRIPTION
## 배경
 #13 을 해결합니다.


## 작업 
1. @@foo -> @foo로 삽입되도록 변경
2.  @@만 입력해도 바로 멘션이 열리도록 개선


## 스크린샷

https://github.com/user-attachments/assets/1b918666-55c8-4b86-85b7-d7ae9a03d4e3

